### PR TITLE
Stub basic Canvas and Whiteboard components

### DIFF
--- a/toaru-web/src/App.tsx
+++ b/toaru-web/src/App.tsx
@@ -1,37 +1,13 @@
-import Canvas from "./Canvas";
+import Whiteboard from "./Whiteboard";
 
 const App = () => {
   return (
     <>
-      <h1>Hello world</h1>
-      <Canvas
-        shapes={[
-          {
-            id: "test1",
-            type: "line",
-            points: [
-              { x: 100, y: 100 },
-              { x: 400, y: 200 },
-            ],
-          },
-          {
-            id: "test2",
-            type: "circle",
-            points: [
-              { x: 500, y: 600 },
-              { x: 400, y: 200 },
-            ],
-          },
-          {
-            id: "test3",
-            type: "rectangle",
-            points: [
-              { x: 200, y: 300 },
-              { x: 700, y: 800 },
-            ],
-          },
-        ]}
-      />
+      <h1>Toaru VTT</h1>
+      <p>
+        <i>It ain&apos;t much, but it&apos;s honest work</i>
+      </p>
+      <Whiteboard />
     </>
   );
 };

--- a/toaru-web/src/App.tsx
+++ b/toaru-web/src/App.tsx
@@ -1,3 +1,39 @@
-const App = () => <h1>Hello world</h1>;
+import Canvas from "./Canvas";
+
+const App = () => {
+  return (
+    <>
+      <h1>Hello world</h1>
+      <Canvas
+        shapes={[
+          {
+            id: "test1",
+            type: "line",
+            points: [
+              { x: 100, y: 100 },
+              { x: 400, y: 200 },
+            ],
+          },
+          {
+            id: "test2",
+            type: "circle",
+            points: [
+              { x: 500, y: 600 },
+              { x: 400, y: 200 },
+            ],
+          },
+          {
+            id: "test3",
+            type: "rectangle",
+            points: [
+              { x: 200, y: 300 },
+              { x: 700, y: 800 },
+            ],
+          },
+        ]}
+      />
+    </>
+  );
+};
 
 export default App;

--- a/toaru-web/src/Canvas.tsx
+++ b/toaru-web/src/Canvas.tsx
@@ -1,15 +1,5 @@
-import { useEffect, useRef } from "react";
-
-interface Point {
-  x: number;
-  y: number;
-}
-
-interface Shape {
-  id: string;
-  type: "line" | "rectangle" | "circle";
-  points: Point[];
-}
+import { useEffect, useRef, useState } from "react";
+import { Point, Shape } from "./geometry";
 
 const drawShape = (shape: Shape, ctx: CanvasRenderingContext2D) => {
   const points = shape.points;
@@ -21,7 +11,7 @@ const drawShape = (shape: Shape, ctx: CanvasRenderingContext2D) => {
       ctx.stroke();
       break;
     }
-    case "rectangle": {
+    case "rect": {
       ctx.beginPath();
       ctx.rect(
         points[0].x,
@@ -45,14 +35,20 @@ const drawShape = (shape: Shape, ctx: CanvasRenderingContext2D) => {
       ctx.stroke();
       break;
     }
-    default:
-      // TODO figure out proper error handling
-      alert("unhandled shape type! " + shape.type);
   }
 };
 
-const Canvas = ({ shapes }: { shapes: Shape[] }) => {
+const Canvas = ({
+  shapes,
+  onPointerDown,
+  onPointerMove,
+}: {
+  shapes: Shape[];
+  onPointerDown: (p: Point) => void;
+  onPointerMove: (p: Point) => void;
+}) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [drawing, setDrawing] = useState(false);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -73,7 +69,36 @@ const Canvas = ({ shapes }: { shapes: Shape[] }) => {
     ctx.drawImage(offscreenCanvas, 0, 0);
   }, [shapes]);
 
-  return <canvas width="2000" height="2000" ref={canvasRef} />;
+  return (
+    <canvas
+      width="2000"
+      height="2000"
+      onPointerDown={(evt) => {
+        evt.stopPropagation();
+        setDrawing(true);
+        const rect = canvasRef.current!.getBoundingClientRect();
+        onPointerDown({
+          x: evt.clientX - rect.left,
+          y: evt.clientY - rect.top,
+        });
+      }}
+      onPointerMove={(evt) => {
+        evt.stopPropagation();
+        if (drawing) {
+          const rect = canvasRef.current!.getBoundingClientRect();
+          onPointerMove({
+            x: evt.clientX - rect.left,
+            y: evt.clientY - rect.top,
+          });
+        }
+      }}
+      onPointerUp={(evt) => {
+        evt.stopPropagation();
+        setDrawing(false);
+      }}
+      ref={canvasRef}
+    />
+  );
 };
 
 export default Canvas;

--- a/toaru-web/src/Canvas.tsx
+++ b/toaru-web/src/Canvas.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useRef } from "react";
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+interface Shape {
+  id: string;
+  type: "line" | "rectangle" | "circle";
+  points: Point[];
+}
+
+const drawShape = (shape: Shape, ctx: CanvasRenderingContext2D) => {
+  const points = shape.points;
+  switch (shape.type) {
+    case "line": {
+      ctx.beginPath();
+      ctx.moveTo(points[0].x, points[0].y);
+      ctx.lineTo(points[1].x, points[1].y);
+      ctx.stroke();
+      break;
+    }
+    case "rectangle": {
+      ctx.beginPath();
+      ctx.rect(
+        points[0].x,
+        points[0].y,
+        points[1].x - points[0].x,
+        points[1].y - points[0].y
+      );
+      ctx.stroke();
+      break;
+    }
+    case "circle": {
+      ctx.beginPath();
+      const radius = Math.round(
+        Math.sqrt(
+          Math.pow(points[1].y - points[0].y, 2) +
+            Math.pow(points[1].x - points[0].x, 2)
+        )
+      );
+      console.log(shape, radius);
+      ctx.arc(points[0].x, points[0].y, radius, 0, 2 * Math.PI);
+      ctx.stroke();
+      break;
+    }
+    default:
+      // TODO figure out proper error handling
+      alert("unhandled shape type! " + shape.type);
+  }
+};
+
+const Canvas = ({ shapes }: { shapes: Shape[] }) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext("2d");
+    if (!canvas || !ctx) return;
+
+    // To speed up rendering and prevent flickering, we do all the hard work on
+    // an offscreen canvas first, and render in one step. ref:
+    // https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Optimizing_canvas
+    const offscreenCanvas = document.createElement("canvas");
+    offscreenCanvas.width = canvas.width;
+    offscreenCanvas.height = canvas.height;
+    const offscreenCtx = offscreenCanvas.getContext("2d")!;
+
+    shapes.forEach((shape) => drawShape(shape, offscreenCtx));
+
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(offscreenCanvas, 0, 0);
+  }, [shapes]);
+
+  return <canvas width="2000" height="2000" ref={canvasRef} />;
+};
+
+export default Canvas;

--- a/toaru-web/src/Whiteboard.test.tsx
+++ b/toaru-web/src/Whiteboard.test.tsx
@@ -1,21 +1,12 @@
 import { reducer } from "./Whiteboard";
-import { Point, Shape } from "./geometry";
-
-const testLine = (id: string, points: Point[]): Shape => ({
-  id,
-  type: "line",
-  points,
-});
+import { line, Shape } from "./geometry";
 
 describe("reducer", () => {
   test("creates a shape", () => {
     const initialState: Shape[] = [];
     const action = {
       type: "create" as const,
-      shape: testLine("1", [
-        { x: 0, y: 0 },
-        { x: 10, y: 10 },
-      ]),
+      shape: line({ x: 0, y: 0 }, { x: 10, y: 10 }),
     };
     const newState = reducer(initialState, action);
 
@@ -24,17 +15,12 @@ describe("reducer", () => {
   });
 
   test("updates a shape's points", () => {
-    const initialState: Shape[] = [
-      testLine("1", [
-        { x: 0, y: 0 },
-        { x: 10, y: 10 },
-      ]),
-    ];
+    const initialState: Shape[] = [line({ x: 0, y: 0 }, { x: 10, y: 10 })];
     const updatedPoints = [
       { x: 5, y: 5 },
       { x: 15, y: 15 },
     ];
-    const action = { type: "update" as const, id: "1", points: updatedPoints };
+    const action = { type: "update" as const, id: initialState[0].id, points: updatedPoints };
     const newState = reducer(initialState, action);
 
     expect(newState).toHaveLength(1);
@@ -42,28 +28,18 @@ describe("reducer", () => {
   });
 
   test("deletes a shape", () => {
-    const initialState: Shape[] = [
-      testLine("1", [
-        { x: 0, y: 0 },
-        { x: 10, y: 10 },
-      ]),
-    ];
-    const action = { type: "delete" as const, id: "1" };
+    const initialState: Shape[] = [line({ x: 0, y: 0 }, { x: 10, y: 10 })];
+    const action = { type: "delete" as const, id: initialState[0].id };
     const newState = reducer(initialState, action);
 
     expect(newState).toHaveLength(0);
   });
 
   test("ignores updates to non-existent shapes", () => {
-    const initialState: Shape[] = [
-      testLine("1", [
-        { x: 0, y: 0 },
-        { x: 10, y: 10 },
-      ]),
-    ];
+    const initialState: Shape[] = [line({ x: 0, y: 0 }, { x: 10, y: 10 })];
     const action = {
       type: "update" as const,
-      id: "2",
+      id: "nonexistent",
       points: [
         { x: 5, y: 5 },
         { x: 15, y: 15 },

--- a/toaru-web/src/Whiteboard.test.tsx
+++ b/toaru-web/src/Whiteboard.test.tsx
@@ -1,0 +1,76 @@
+import { reducer } from "./Whiteboard";
+import { Point, Shape } from "./geometry";
+
+const testLine = (id: string, points: Point[]): Shape => ({
+  id,
+  type: "line",
+  points,
+});
+
+describe("reducer", () => {
+  test("creates a shape", () => {
+    const initialState: Shape[] = [];
+    const action = {
+      type: "create" as const,
+      shape: testLine("1", [
+        { x: 0, y: 0 },
+        { x: 10, y: 10 },
+      ]),
+    };
+    const newState = reducer(initialState, action);
+
+    expect(newState).toHaveLength(1);
+    expect(newState[0]).toMatchObject(action.shape);
+  });
+
+  test("updates a shape's points", () => {
+    const initialState: Shape[] = [
+      testLine("1", [
+        { x: 0, y: 0 },
+        { x: 10, y: 10 },
+      ]),
+    ];
+    const updatedPoints = [
+      { x: 5, y: 5 },
+      { x: 15, y: 15 },
+    ];
+    const action = { type: "update" as const, id: "1", points: updatedPoints };
+    const newState = reducer(initialState, action);
+
+    expect(newState).toHaveLength(1);
+    expect(newState[0].points).toEqual(updatedPoints);
+  });
+
+  test("deletes a shape", () => {
+    const initialState: Shape[] = [
+      testLine("1", [
+        { x: 0, y: 0 },
+        { x: 10, y: 10 },
+      ]),
+    ];
+    const action = { type: "delete" as const, id: "1" };
+    const newState = reducer(initialState, action);
+
+    expect(newState).toHaveLength(0);
+  });
+
+  test("ignores updates to non-existent shapes", () => {
+    const initialState: Shape[] = [
+      testLine("1", [
+        { x: 0, y: 0 },
+        { x: 10, y: 10 },
+      ]),
+    ];
+    const action = {
+      type: "update" as const,
+      id: "2",
+      points: [
+        { x: 5, y: 5 },
+        { x: 15, y: 15 },
+      ],
+    };
+    const newState = reducer(initialState, action);
+
+    expect(newState).toEqual(initialState);
+  });
+});

--- a/toaru-web/src/Whiteboard.tsx
+++ b/toaru-web/src/Whiteboard.tsx
@@ -9,7 +9,7 @@ type Action =
   | { type: "update"; id: string; points: Point[] }
   | { type: "delete"; id: string };
 
-const reducer = (shapes: Shape[], action: Action): Shape[] => {
+export const reducer = (shapes: Shape[], action: Action): Shape[] => {
   switch (action.type) {
     case "create":
       return [...shapes, action.shape];
@@ -41,6 +41,10 @@ const handlePointerMove = (
   dispatch: React.Dispatch<Action>
 ) => {
   if (tool !== "pen") return;
+  // TODO when we get to concurrent editing, the last shape may change over the
+  // course of a draw. How can we model tracking the shape ID as part of
+  // drawing? Maybe switch from `useState<bool>` to `useState<string | null>` in
+  // Canvas?
   const lastShape = shapes[shapes.length - 1];
   if (lastShape?.type === "line") {
     dispatch({

--- a/toaru-web/src/Whiteboard.tsx
+++ b/toaru-web/src/Whiteboard.tsx
@@ -1,0 +1,70 @@
+import { useReducer, useState } from "react";
+import Canvas from "./Canvas";
+import { Point, Shape, line } from "./geometry";
+
+type Tool = "pen" | "eraser" | "select";
+
+type Action =
+  | { type: "create"; shape: Shape }
+  | { type: "update"; id: string; points: Point[] }
+  | { type: "delete"; id: string };
+
+const reducer = (shapes: Shape[], action: Action): Shape[] => {
+  switch (action.type) {
+    case "create":
+      return [...shapes, action.shape];
+    case "update":
+      return shapes.map((s) =>
+        s.id === action.id ? { ...s, points: action.points } : s
+      );
+    case "delete":
+      return shapes.filter((s) => s.id !== action.id);
+    default:
+      return shapes;
+  }
+};
+
+const handlePointerDown = (
+  point: Point,
+  tool: Tool,
+  dispatch: React.Dispatch<Action>
+) => {
+  if (tool === "pen") {
+    dispatch({ type: "create", shape: line(point, point) });
+  }
+};
+
+const handlePointerMove = (
+  point: Point,
+  tool: Tool,
+  shapes: Shape[],
+  dispatch: React.Dispatch<Action>
+) => {
+  if (tool !== "pen") return;
+  const lastShape = shapes[shapes.length - 1];
+  if (lastShape?.type === "line") {
+    dispatch({
+      type: "update",
+      id: lastShape.id,
+      points: [lastShape.points[0], point],
+    });
+  }
+};
+
+const Whiteboard = () => {
+  const [shapes, dispatch] = useReducer(reducer, []);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [tool, setTool] = useState<Tool>("pen");
+
+  return (
+    <Canvas
+      shapes={shapes}
+      onPointerDown={(point: Point) => handlePointerDown(point, tool, dispatch)}
+      onPointerMove={(point: Point) =>
+        handlePointerMove(point, tool, shapes, dispatch)
+      }
+    />
+  );
+};
+
+export default Whiteboard;

--- a/toaru-web/src/geometry.ts
+++ b/toaru-web/src/geometry.ts
@@ -1,0 +1,43 @@
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface Shape {
+  id: string;
+  type: "line" | "rect" | "circle";
+  points: Point[];
+}
+
+const genId = (): string => {
+  return Math.random().toString(16).slice(2);
+};
+
+export const line = (start: Point, end: Point): Shape => {
+  return {
+    id: genId(),
+    type: "line",
+    points: [start, end],
+  };
+};
+
+export const circle = (center: Point, radius: number): Shape => {
+  return {
+    id: genId(),
+    type: "circle",
+    points: [center, { x: Math.round(radius), y: center.y }],
+  };
+};
+
+export const rect = (start: Point, end: Point): Shape => {
+  // Canvas render requires that the points go from top left to bottom right
+  const [reboxStart, reboxEnd] = [
+    { x: Math.min(start.x, end.x), y: Math.min(start.y, end.y) },
+    { x: Math.max(start.x, end.x), y: Math.max(start.y, end.y) },
+  ];
+  return {
+    id: genId(),
+    type: "rect",
+    points: [reboxStart, reboxEnd],
+  };
+};

--- a/toaru-web/src/index.html
+++ b/toaru-web/src/index.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <title>Parcel Preact Typescript</title>
+    <title>Toaru VTT</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Currently just allows click+drag drawing of a straight line, with some groundwork for further shapes. I'm trying to keep all the actions mostly as pure functions, so it stays testable. CSS and dynamic canvas sizing is left as an exercise.

Ideally, Canvas should serve as a protective barrier between events/rendering and the rest of the application, so we can get away with testing it relatively lightly and test everything else more heavily. Still, probably I could stand to write some tests for the state management of Canvas (onclick events and so on). Problem for future me, probably -- there's a TODO in-code for when I get back to it.
